### PR TITLE
Upgrade to richie 42

### DIFF
--- a/sites/cnfpt/requirements/base.txt
+++ b/sites/cnfpt/requirements/base.txt
@@ -7,7 +7,7 @@ django-storages==1.9.1
 dockerflow==2020.6.0
 gunicorn==20.0.4
 psycopg2-binary==2.8.6
-richie==2.0.0-beta.15
+richie==42
 sentry-sdk==0.18.0
 
 # Google sheet importer

--- a/sites/cnfpt/src/frontend/package.json
+++ b/sites/cnfpt/src/frontend/package.json
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/openfun/richie-site-factory#readme",
   "dependencies": {
-    "richie-education": "2.0.0-beta.15"
+    "richie-education": "42"
   },
   "devDependencies": {
     "eslint": "7.10.0",

--- a/sites/demo/requirements/base.txt
+++ b/sites/demo/requirements/base.txt
@@ -5,5 +5,5 @@ django-storages==1.9.1
 dockerflow==2020.6.0
 gunicorn==20.0.4
 psycopg2-binary==2.8.6
-richie==2.0.0-beta.15
+richie==42
 sentry-sdk==0.18.0

--- a/sites/demo/src/frontend/package.json
+++ b/sites/demo/src/frontend/package.json
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/openfun/richie-site-factory#readme",
   "dependencies": {
-    "richie-education": "2.0.0-beta.15"
+    "richie-education": "42"
   },
   "devDependencies": {
     "eslint": "7.10.0",

--- a/sites/funcampus/requirements/base.txt
+++ b/sites/funcampus/requirements/base.txt
@@ -7,7 +7,7 @@ django-storages==1.9.1
 dockerflow==2020.6.0
 gunicorn==20.0.4
 psycopg2-binary==2.8.6
-richie==2.0.0-beta.15
+richie==42
 sentry-sdk==0.18.0
 
 # Google sheet importer

--- a/sites/funcampus/src/frontend/package.json
+++ b/sites/funcampus/src/frontend/package.json
@@ -32,7 +32,7 @@
   "homepage": "https://github.com/openfun/richie-site-factory#readme",
   "dependencies": {
     "react": "16.13.1",
-    "richie-education": "2.0.0-beta.15"
+    "richie-education": "42"
   },
   "devDependencies": {
     "eslint": "7.10.0",

--- a/sites/funcorporate/requirements/base.txt
+++ b/sites/funcorporate/requirements/base.txt
@@ -7,7 +7,7 @@ django-storages==1.9.1
 dockerflow==2020.6.0
 gunicorn==20.0.4
 psycopg2-binary==2.8.6
-richie==2.0.0-beta.15
+richie==42
 sentry-sdk==0.18.0
 
 # Google sheet importer

--- a/sites/funcorporate/src/frontend/package.json
+++ b/sites/funcorporate/src/frontend/package.json
@@ -32,7 +32,7 @@
   "homepage": "https://github.com/openfun/richie-site-factory#readme",
   "dependencies": {
     "react": "16.13.1",
-    "richie-education": "2.0.0-beta.15"
+    "richie-education": "42"
   },
   "devDependencies": {
     "eslint": "7.10.0",

--- a/sites/funmooc/requirements/base.txt
+++ b/sites/funmooc/requirements/base.txt
@@ -7,7 +7,7 @@ django-storages==1.9.1
 dockerflow==2020.6.0
 gunicorn==20.0.4
 psycopg2-binary==2.8.6
-richie==2.0.0-beta.15
+richie==42
 sentry-sdk==0.18.0
 
 # Google sheet importer

--- a/sites/funmooc/src/frontend/package.json
+++ b/sites/funmooc/src/frontend/package.json
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/openfun/richie-site-factory#readme",
   "dependencies": {
-    "richie-education": "2.0.0-beta.15"
+    "richie-education": "42"
   },
   "devDependencies": {
     "eslint": "7.10.0",


### PR DESCRIPTION
⬆️(funcorporate) upgrade richie to v42
⬆️(funmooc) upgrade richie to v42
⬆️(funcampus) upgrade richie to v42
⬆️(cnfpt) upgrade richie to v42
⬆️(demo) upgrade richie to v42
Changelog available at https://github.com/openfun/richie/releases/tag/v42